### PR TITLE
Read OBD commands to run from preferences, update result view

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
@@ -354,8 +355,11 @@ public class MainActivity extends RoboActivity implements ObdProgressListener {
 
   private void addTableRow(String key, String val) {
         TextView existingTV = (TextView) tl.findViewWithTag(key);
-        if  (existingTV != null)
+        if  (existingTV != null) {
+            if (existingTV.getText() == val) existingTV.setTypeface(Typeface.DEFAULT);
+            else existingTV.setTypeface(Typeface.DEFAULT_BOLD);
             existingTV.setText(val);
+        }
         else {
     TableRow tr = new TableRow(this);
     MarginLayoutParams params = new ViewGroup.MarginLayoutParams(


### PR DESCRIPTION
-Read OBD commands to run from preferences (no need no import, define  and queue commands individually here anymore or ) ,
-update TextView with results instead of keep creating new textviews (by tagging textview with command name ,  ignoring result of some results from housekeeping obd commands),
-clear all on starting live data (thus also when preferences have changed) ,  
-Mark updated values in bold
