### PR TITLE
fixes issue where impossible to connect to OBD device if first attempt fails.

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
@@ -32,6 +32,7 @@ import android.widget.Toast;
 
 import com.google.inject.Inject;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -134,7 +135,11 @@ public class MainActivity extends RoboActivity implements ObdProgressListener {
       service = ((AbstractGatewayService.AbstractGatewayServiceBinder)binder).getService();
       service.setContext(MainActivity.this);
       Log.d(TAG, "Starting the live data");
-      service.startService();
+      try { service.startService(); }
+      catch ( IOException ioe) {
+          Log.e(TAG, "Failure Starting the live data");
+          doUnbindService();
+        }
 
     }
 

--- a/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
@@ -134,10 +134,10 @@ public class MainActivity extends RoboActivity implements ObdProgressListener {
       isServiceBound = true;
       service = ((AbstractGatewayService.AbstractGatewayServiceBinder)binder).getService();
       service.setContext(MainActivity.this);
-      Log.d(TAG, "Starting the live data");
+      Log.d(TAG, "Starting live data");
       try { service.startService(); }
       catch ( IOException ioe) {
-          Log.e(TAG, "Failure Starting the live data");
+          Log.e(TAG, "Failure Starting live data");
           doUnbindService();
         }
 

--- a/src/main/java/pt/lighthouselabs/obd/reader/io/AbstractGatewayService.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/io/AbstractGatewayService.java
@@ -12,6 +12,7 @@ import android.util.Log;
 
 import com.google.inject.Inject;
 
+import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -128,6 +129,6 @@ public abstract class AbstractGatewayService extends RoboService {
   }
 
   abstract protected void executeQueue();
-  abstract public void startService();
+  abstract public void startService() throws IOException;
   abstract public void stopService();
 }

--- a/src/main/java/pt/lighthouselabs/obd/reader/io/ObdGatewayService.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/io/ObdGatewayService.java
@@ -67,7 +67,7 @@ public class ObdGatewayService extends AbstractGatewayService {
   private BluetoothSocket sock = null;
   private BluetoothSocket sockFallback = null;
 
-  public void startService() {
+  public void startService() throws IOException {
     Log.d(TAG, "Starting service..");
 
     // get the remote Bluetooth device
@@ -80,6 +80,7 @@ public class ObdGatewayService extends AbstractGatewayService {
 
       // TODO kill this service gracefully
       stopService();
+      throw new IOException();
       } else {
 
     final BluetoothAdapter btAdapter = BluetoothAdapter.getDefaultAdapter();
@@ -116,6 +117,7 @@ public class ObdGatewayService extends AbstractGatewayService {
 
       // in case of failure, stop this service.
       stopService();
+      throw new IOException();
     }
     }
 
@@ -157,7 +159,7 @@ public class ObdGatewayService extends AbstractGatewayService {
       } catch (Exception e2) {
         Log.e(TAG, "Couldn't fallback while establishing Bluetooth connection. Stopping app..", e2);
         stopService();
-        return;
+        throw new IOException();
       }
     }
 

--- a/src/main/java/pt/lighthouselabs/obd/reader/io/ObdGatewayService.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/io/ObdGatewayService.java
@@ -139,7 +139,7 @@ public class ObdGatewayService extends AbstractGatewayService {
    */
   private void startObdConnection() throws IOException {
     Log.d(TAG, "Starting OBD connection..");
-
+    isRunning = true;
     try {
       // Instantiate a BluetoothSocket for the remote device and connect it.
       sock = dev.createRfcommSocketToServiceRecord(MY_UUID);
@@ -186,7 +186,7 @@ public class ObdGatewayService extends AbstractGatewayService {
     queueCounter = 0L;
     Log.d(TAG, "Initialization jobs queued.");
 
-    isRunning = true;
+
   }
 
   /**


### PR DESCRIPTION
issue is that onServiceConnected never get called again because service is still running after connection attempt fails, solution is to catch error and call doUnbindService() explicitly.

not convinced that throwing around IOExceptions is the best solution but startObdConnection() was already using those, open for better suggestions. 