### PR TITLE
applied some threading love.

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/reader/io/MockObdGatewayService.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/io/MockObdGatewayService.java
@@ -67,8 +67,7 @@ public class MockObdGatewayService extends AbstractGatewayService {
     */
     protected void executeQueue() {
       Log.d(TAG, "Executing queue..");
-      isQueueRunning = true;
-      while (!jobsQueue.isEmpty()) {
+      while (!Thread.currentThread().isInterrupted()) {
           ObdCommandJob job = null;
           try {
             job = jobsQueue.take();
@@ -83,6 +82,8 @@ public class MockObdGatewayService extends AbstractGatewayService {
             } else {
               Log.e(TAG, "Job state was not new, so it shouldn't be in queue. BUG ALERT!");
             }
+          } catch (InterruptedException i) {
+              Thread.currentThread().interrupt();
           } catch (Exception e) {
             e.printStackTrace();
             job.setState(ObdCommandJobState.EXECUTION_ERROR);
@@ -102,8 +103,6 @@ public class MockObdGatewayService extends AbstractGatewayService {
 
           }
       }
-      // will run next time a job is queued
-      isQueueRunning = false;
     }
 
 

--- a/src/main/java/pt/lighthouselabs/obd/reader/io/ObdGatewayService.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/io/ObdGatewayService.java
@@ -194,10 +194,9 @@ public class ObdGatewayService extends AbstractGatewayService {
   /**
    * Runs the queue until the service is stopped
    */
-  protected void executeQueue() {
+  protected void executeQueue() throws InterruptedException{
     Log.d(TAG, "Executing queue..");
-    isQueueRunning = true;
-    while (!jobsQueue.isEmpty()) {
+    while (!Thread.currentThread().isInterrupted()) {
       ObdCommandJob job = null;
       try {
         job = jobsQueue.take();
@@ -213,6 +212,8 @@ public class ObdGatewayService extends AbstractGatewayService {
           // log not new job
           Log.e(TAG,
               "Job state was not new, so it shouldn't be in queue. BUG ALERT!");
+            } catch (InterruptedException i) {
+                Thread.currentThread().interrupt();
       } catch (Exception e) {
         job.setState(ObdCommandJobState.EXECUTION_ERROR);
         Log.e(TAG, "Failed to run command. -> " + e.getMessage());
@@ -228,8 +229,6 @@ public class ObdGatewayService extends AbstractGatewayService {
         });
       }
     }
-    // will run next time a job is queued
-    isQueueRunning = false;
   }
 
   /**


### PR DESCRIPTION
AbstractGatewayService.java: instead of (potentially) starting a new executeQueue thread every time queueJob is called, only start it _once_ in onCreate and more
 importantly have it interrupted by onDestroy. this means a new thread is started when service is created and asked nicely to stop when service is destroyed
(Mock)ObdGatewayService.java: try to handle the thread interruption by bailing out when thread is interrupted and catching InterruptedException (and re-throwing it),
no need for isQueueRunning flag anymore.
This resolves issue where multiple executeQueue threads are reading from stream at same time resulting in garbage out. in theory it should only have started new
thread when none is running and stopped when the queue was empty but this is wasn't always working. also no need to stop the thread when queue is empty it will
happily sit and wait for it to be refilled again so we can just have one thread.