### PR TITLE
Fix ...IndexOutOfBoundsException if device don't have orientation sensor

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
@@ -34,6 +34,7 @@ import com.google.inject.Inject;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import pt.lighthouselabs.obd.commands.ObdCommand;
@@ -255,11 +256,12 @@ public class MainActivity extends RoboActivity implements ObdProgressListener {
       Toast.makeText(this, "Bluetooth ok", Toast.LENGTH_SHORT).show();
     }
 
-
     // get Orientation sensor
-    orientSensor = sensorManager.getSensorList(Sensor.TYPE_ORIENTATION).get(0);
-    if (orientSensor == null)
-      showDialog(NO_ORIENTATION_SENSOR);
+    List<Sensor> sensors = sensorManager.getSensorList(Sensor.TYPE_ORIENTATION);
+    if (sensors.size() > 0)
+        orientSensor = sensors.get(0);
+    else
+        showDialog(NO_ORIENTATION_SENSOR);
   }
 
   private void updateConfig() {


### PR DESCRIPTION
What steps will reproduce the problem?
1. Run app on Lenovo S820
2. Get java.lang.IndexOutOfBoundsException: Invalid index 0, size is 0 in 260 line MainActivity.java:
orientSensor = sensorManager.getSensorList(Sensor.TYPE_ORIENTATION).get(0);
This occurs because the list does not include items that are returned getSensorList.