### PR TITLE
Enabling Upload 

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
@@ -240,26 +240,26 @@ public class MainActivity extends RoboActivity implements ObdProgressListener {
     wakeLock = powerManager.newWakeLock(PowerManager.SCREEN_DIM_WAKE_LOCK,
         "ObdReader");
 
-      // get Bluetooth device
-      final BluetoothAdapter btAdapter = BluetoothAdapter
-              .getDefaultAdapter();
+    // get Bluetooth device
+    final BluetoothAdapter btAdapter = BluetoothAdapter
+        .getDefaultAdapter();
 
-      preRequisites = btAdapter == null ? false : true;
-      if (preRequisites)
-          preRequisites = btAdapter.isEnabled();
+    preRequisites = btAdapter == null ? false : true;
+    if (preRequisites)
+      preRequisites = btAdapter.isEnabled();
 
-      if (!preRequisites) {
-          showDialog(BLUETOOTH_DISABLED);
-          Toast.makeText(this, "Bluetooth is disabled, will use Mock service instead", Toast.LENGTH_SHORT).show();
-      } else {
-          Toast.makeText(this, "Bluetooth ok", Toast.LENGTH_SHORT).show();
-      }
+    if (!preRequisites) {
+      showDialog(BLUETOOTH_DISABLED);
+      Toast.makeText(this, "Bluetooth is disabled, will use Mock service instead", Toast.LENGTH_SHORT).show();
+    } else {
+      Toast.makeText(this, "Bluetooth ok", Toast.LENGTH_SHORT).show();
+    }
 
 
-      // get Orientation sensor
-      orientSensor = sensorManager.getSensorList(Sensor.TYPE_ORIENTATION).get(0);
-      if (orientSensor == null)
-          showDialog(NO_ORIENTATION_SENSOR);
+    // get Orientation sensor
+    orientSensor = sensorManager.getSensorList(Sensor.TYPE_ORIENTATION).get(0);
+    if (orientSensor == null)
+      showDialog(NO_ORIENTATION_SENSOR);
   }
 
   private void updateConfig() {

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -10,16 +10,14 @@
       android:title="Enable Data Upload"
       android:summaryOff="Disable http data upload"
       android:summaryOn="Enable http data upload"
-      android:dialogTitle="Enable Data Upload"
-      android:enabled="false"/>
+      android:dialogTitle="Enable Data Upload"/>
 
     <EditTextPreference
       android:key="upload_url_preference"
-      android:defaultValue="http://www.ral.ucar.edu/~lambi/obd/get_data.php"
+      android:defaultValue="http://www.example.com/obd/get_data.php"
       android:title="Upload URL"
       android:summary="POST URL that will accept real-time data"
-      android:dialogTitle="Upload URL"
-      android:enabled="false"/>
+      android:dialogTitle="Upload URL"/>
 
     <EditTextPreference
       android:key="vehicle_id_preference"


### PR DESCRIPTION
* Enable upload preferences
* Set default endpoint to example.com
* Use values from preferences in MainActivity
* Catch and log upload exceptions
* Update readme

any good reason to leave this disabled?

noticed some strange behaviour after changing the default endpoint on my device it was still set to http://www.ral.ucar.edu/~lambi/obd/get_data.php , maybe i'm missing something about the way preferences are updated?