### PR TITLE
Show GPS settings only if supported by the device. Cut lan/lon strings.

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/reader/activity/ConfigActivity.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/activity/ConfigActivity.java
@@ -3,7 +3,10 @@ package pt.lighthouselabs.obd.reader.activity;
 import android.app.Activity;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
+import android.content.Context;
 import android.content.SharedPreferences;
+import android.location.LocationManager;
+import android.location.LocationProvider;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
@@ -12,6 +15,7 @@ import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceCategory;
 import android.preference.PreferenceScreen;
 import android.widget.Toast;
 
@@ -190,6 +194,8 @@ public class ConfigActivity extends PreferenceActivity implements
      */
     addPreferencesFromResource(R.xml.preferences);
 
+    checkGps();
+
     ArrayList<CharSequence> pairedDeviceStrings = new ArrayList<CharSequence>();
     ArrayList<CharSequence> vals = new ArrayList<CharSequence>();
     ListPreference listBtDevices = (ListPreference) getPreferenceScreen()
@@ -308,4 +314,22 @@ public class ConfigActivity extends PreferenceActivity implements
     return false;
   }
 
+  private void checkGps() {
+    LocationManager mLocService = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+    if(mLocService != null ) {
+      LocationProvider mLocProvider = mLocService.getProvider(LocationManager.GPS_PROVIDER);
+      if (mLocProvider == null) {
+        hideGPSCategory();
+      }
+    }
+  }
+
+  private void hideGPSCategory() {
+    PreferenceScreen preferenceScreen = getPreferenceScreen();
+    PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference(getResources().getString(R.string.pref_gps_category));
+    if(preferenceCategory != null) {
+      preferenceCategory.removeAll();
+      preferenceScreen.removePreference((Preference) preferenceCategory);
+    }
+  }
 }

--- a/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
+++ b/src/main/java/pt/lighthouselabs/obd/reader/activity/MainActivity.java
@@ -126,6 +126,7 @@ public class MainActivity extends RoboActivity implements ObdProgressListener, L
 
         double lat = 0;
         double lon = 0;
+        final int posLen = 7;
         if(mGpsIsStarted && mLastLocation != null) {
           lat = mLastLocation.getLatitude();
           lon = mLastLocation.getLongitude();
@@ -133,9 +134,9 @@ public class MainActivity extends RoboActivity implements ObdProgressListener, L
           TextView gpsPos = (TextView) vv.findViewWithTag("GPS_POS");
           StringBuffer sb = new StringBuffer();
           sb.append("Lat: ");
-          sb.append(mLastLocation.getLatitude());
+          sb.append(String.valueOf(mLastLocation.getLatitude()).substring(0, posLen));
           sb.append(" Lon: ");
-          sb.append(mLastLocation.getLongitude());
+          sb.append(String.valueOf(mLastLocation.getLongitude()).substring(0, posLen));
           gpsPos.setText(sb.toString());
         }
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
   <string name="title_activity_trouble_codes">Trouble Codes</string>
   <string name="pref_upload_category_title">Data Upload</string>
   <string name="pref_upload_category">upload_category</string>
+  <string name="pref_gps_category">gps_category</string>
 </resources>

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -40,7 +40,8 @@
         android:title="Bluetooth Devices"/>
   </PreferenceCategory>
   <PreferenceCategory
-      android:title="Bluetooth">
+      android:title="GPS"
+      android:key="@string/pref_gps_category" >
     <CheckBoxPreference
         android:defaultValue="false"
         android:dialogTitle="Enable GPS"


### PR DESCRIPTION
Todo: Make a determination of support gps, orientation sensor as well as other similar devices in a separate class.