### PR TITLE
Tweaked Theme & AppName

### DIFF
--- a/src/main/res/values-v21/styles.xml
+++ b/src/main/res/values-v21/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="AppBaseTheme" parent="android:Theme.Material.Light">
+    <style name="AppBaseTheme" parent="android:Theme.Material.Light.DarkActionBar">
 
         <!--    color for the app bar -->
         <item name="android:colorPrimary">@color/primary</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name" translatable="false">Android OBD-II Reader</string>
+    <string name="app_name" translatable="false">OBD-II Reader</string>
     <string name="action_settings">Settings</string>
     <string name="action_clear_codes">Clear Codes</string>
     <string name="notification_action">Tap to open OBD-Reader</string>


### PR DESCRIPTION
Fixed Material Theme. Text was Black which should have been white for better visibility.
Shortened app name to fit on Launcher.



