### PR TITLE
Fix for issue https://github.com/pires/obd-java-api/issues/98

### DIFF
--- a/src/main/java/com/github/pires/obd/reader/io/ObdGatewayService.java
+++ b/src/main/java/com/github/pires/obd/reader/io/ObdGatewayService.java
@@ -123,6 +123,10 @@ public class ObdGatewayService extends AbstractGatewayService {
         // Let's configure the connection.
         Log.d(TAG, "Queueing jobs for connection configuration..");
         queueJob(new ObdCommandJob(new ObdResetCommand()));
+        
+        //Below is to give the adapter enough time to reset before sending the commands, otherwise the first startup commands could be ignored.
+        try { Thread.sleep(500); } catch (InterruptedException e) { e.printStackTrace(); }
+        
         queueJob(new ObdCommandJob(new EchoOffCommand()));
 
     /*


### PR DESCRIPTION
This fixes issues where commands are passed before the adapter has completely reset, thus losing some of the startup commands.

